### PR TITLE
convert shaders from version 1.30 to 1.10 for mac support

### DIFF
--- a/src/main/resources/assets/flexfov/shaders/cubic.fs
+++ b/src/main/resources/assets/flexfov/shaders/cubic.fs
@@ -1,7 +1,7 @@
-#version 130
+#version 110
 
 /* This comes interpolated from the vertex shader */
-in vec2 texcoord;
+varying vec2 texcoord;
 
 /* The 6 textures to be rendered */
 uniform sampler2D texFront;
@@ -20,8 +20,6 @@ uniform vec4 backgroundColor;
 uniform vec2 cursorPos;
 
 uniform bool drawCursor;
-
-out vec4 color;
 
 void main(void) {
 	//Anti-aliasing
@@ -76,12 +74,12 @@ void main(void) {
 	  corner[1] = mix(mix(colorN[3], colorN[2], 2.0/3.0), mix(colorN[7], colorN[6], 3.0/5.0), 5.0/8.0);
 	  corner[2] = mix(mix(colorN[12], colorN[13], 2.0/3.0), mix(colorN[8], colorN[9], 3.0/5.0), 5.0/8.0);
 	  corner[3] = mix(mix(colorN[15], colorN[14], 2.0/3.0), mix(colorN[11], colorN[10], 3.0/5.0), 5.0/8.0);
-	  color = mix(mix(corner[0], corner[1], 0.5), mix(corner[2], corner[3], 0.5), 0.5);
+	  gl_FragColor = mix(mix(corner[0], corner[1], 0.5), mix(corner[2], corner[3], 0.5), 0.5);
 	}
 	else if (antialiasing == 4) {
-		color = mix(mix(colorN[0], colorN[1], 0.5), mix(colorN[2], colorN[3], 0.5), 0.5);
+		gl_FragColor = mix(mix(colorN[0], colorN[1], 0.5), mix(colorN[2], colorN[3], 0.5), 0.5);
 	}
 	else { //if antialiasing == 1
-		color = colorN[0];
+		gl_FragColor = colorN[0];
 	}
 }

--- a/src/main/resources/assets/flexfov/shaders/cylinder.fs
+++ b/src/main/resources/assets/flexfov/shaders/cylinder.fs
@@ -1,9 +1,9 @@
-#version 130
+#version 110
 
 #define M_PI 3.14159265
 
 /* This comes interpolated from the vertex shader */
-in vec2 texcoord;
+varying vec2 texcoord;
 
 /* The 6 textures to be rendered */
 uniform sampler2D texFront;
@@ -19,8 +19,6 @@ uniform vec2 pixelOffset[16];
 
 uniform float fovx;
 uniform float fovy;
-
-out vec4 color;
 
 vec3 rotate(vec3 ray, vec2 angle) {
 
@@ -107,12 +105,12 @@ void main(void) {
 	  corner[1] = mix(mix(colorN[3], colorN[2], 2.0/3.0), mix(colorN[7], colorN[6], 3.0/5.0), 5.0/8.0);
 	  corner[2] = mix(mix(colorN[12], colorN[13], 2.0/3.0), mix(colorN[8], colorN[9], 3.0/5.0), 5.0/8.0);
 	  corner[3] = mix(mix(colorN[15], colorN[14], 2.0/3.0), mix(colorN[11], colorN[10], 3.0/5.0), 5.0/8.0);
-	  color = mix(mix(corner[0], corner[1], 0.5), mix(corner[2], corner[3], 0.5), 0.5);
+	  gl_FragColor = mix(mix(corner[0], corner[1], 0.5), mix(corner[2], corner[3], 0.5), 0.5);
 	}
 	else if (antialiasing == 4) {
-		color = mix(mix(colorN[0], colorN[1], 0.5), mix(colorN[2], colorN[3], 0.5), 0.5);
+		gl_FragColor = mix(mix(colorN[0], colorN[1], 0.5), mix(colorN[2], colorN[3], 0.5), 0.5);
 	}
 	else { //if antialiasing == 1
-		color = colorN[0];
+		gl_FragColor = colorN[0];
 	}
 }

--- a/src/main/resources/assets/flexfov/shaders/equirectangular.fs
+++ b/src/main/resources/assets/flexfov/shaders/equirectangular.fs
@@ -1,9 +1,9 @@
-#version 130
+#version 110
 
 #define M_PI 3.14159265
 
 /* This comes interpolated from the vertex shader */
-in vec2 texcoord;
+varying vec2 texcoord;
 
 /* The 6 textures to be rendered */
 uniform sampler2D texFront;
@@ -24,8 +24,6 @@ uniform bool drawCursor;
 uniform bool drawCircle;
 
 uniform vec2 rotation;
-
-out vec4 color;
 
 vec3 rotate(vec3 ray, vec2 angle) {
 
@@ -159,12 +157,12 @@ void main(void) {
 	  corner[1] = mix(mix(colorN[3], colorN[2], 2.0/3.0), mix(colorN[7], colorN[6], 3.0/5.0), 5.0/8.0);
 	  corner[2] = mix(mix(colorN[12], colorN[13], 2.0/3.0), mix(colorN[8], colorN[9], 3.0/5.0), 5.0/8.0);
 	  corner[3] = mix(mix(colorN[15], colorN[14], 2.0/3.0), mix(colorN[11], colorN[10], 3.0/5.0), 5.0/8.0);
-	  color = mix(mix(corner[0], corner[1], 0.5), mix(corner[2], corner[3], 0.5), 0.5);
+	  gl_FragColor = mix(mix(corner[0], corner[1], 0.5), mix(corner[2], corner[3], 0.5), 0.5);
 	}
 	else if (antialiasing == 4) {
-		color = mix(mix(colorN[0], colorN[1], 0.5), mix(colorN[2], colorN[3], 0.5), 0.5);
+		gl_FragColor = mix(mix(colorN[0], colorN[1], 0.5), mix(colorN[2], colorN[3], 0.5), 0.5);
 	}
 	else { //if antialiasing == 1
-		color = colorN[0];
+		gl_FragColor = colorN[0];
 	}
 }

--- a/src/main/resources/assets/flexfov/shaders/error.fs
+++ b/src/main/resources/assets/flexfov/shaders/error.fs
@@ -1,8 +1,7 @@
-#version 130
+#version 110
 
-in vec2 texcoord;
-out vec4 color;
+varying vec2 texcoord;
 
 void main(void) {
-	color = vec4(1, 0, 1, 1);
+	gl_FragColor = vec4(1, 0, 1, 1);
 }

--- a/src/main/resources/assets/flexfov/shaders/fisheye.fs
+++ b/src/main/resources/assets/flexfov/shaders/fisheye.fs
@@ -1,9 +1,9 @@
-#version 130//\n
+#version 110
 
-#define M_PI 3.14159265//\n
+#define M_PI 3.14159265
 
 /* This comes interpolated from the vertex shader */
-in vec2 texcoord;
+varying vec2 texcoord;
 
 /* The 6 textures to be rendered */
 uniform sampler2D texFront;
@@ -28,8 +28,6 @@ uniform vec4 backgroundColor;
 uniform vec2 cursorPos;
 
 uniform bool drawCursor;
-
-out vec4 color;
 
 vec4 fisheye(vec3 ray, float x, float y) {
 	//scale from square view to window shape view //fcontain
@@ -200,12 +198,12 @@ void main(void) {
 	  corner[1] = mix(mix(colorN[3], colorN[2], 2.0/3.0), mix(colorN[7], colorN[6], 3.0/5.0), 5.0/8.0);
 	  corner[2] = mix(mix(colorN[12], colorN[13], 2.0/3.0), mix(colorN[8], colorN[9], 3.0/5.0), 5.0/8.0);
 	  corner[3] = mix(mix(colorN[15], colorN[14], 2.0/3.0), mix(colorN[11], colorN[10], 3.0/5.0), 5.0/8.0);
-	  color = mix(mix(corner[0], corner[1], 0.5), mix(corner[2], corner[3], 0.5), 0.5);
+	  gl_FragColor = mix(mix(corner[0], corner[1], 0.5), mix(corner[2], corner[3], 0.5), 0.5);
 	}
 	else if (antialiasing == 4) {
-		color = mix(mix(colorN[0], colorN[1], 0.5), mix(colorN[2], colorN[3], 0.5), 0.5);
+		gl_FragColor = mix(mix(colorN[0], colorN[1], 0.5), mix(colorN[2], colorN[3], 0.5), 0.5);
 	}
 	else { //if antialiasing == 1
-		color = colorN[0];
+		gl_FragColor = colorN[0];
 	}
 }

--- a/src/main/resources/assets/flexfov/shaders/flex.fs
+++ b/src/main/resources/assets/flexfov/shaders/flex.fs
@@ -1,10 +1,10 @@
-#version 130
+#version 110
 
 #define M_PI 3.14159265
 #define M_E 2.718281828
 
 /* This comes interpolated from the vertex shader */
-in vec2 texcoord;
+varying vec2 texcoord;
 
 /* The 6 textures to be rendered */
 uniform sampler2D texFront;
@@ -20,8 +20,6 @@ uniform vec2 pixelOffset[16];
 
 uniform float fovx;
 uniform float fovy;
-
-out vec4 color;
 
 vec3 rotate(vec3 ray, vec2 angle) {
 
@@ -180,12 +178,12 @@ void main(void) {
 	  corner[1] = mix(mix(colorN[3], colorN[2], 2.0/3.0), mix(colorN[7], colorN[6], 3.0/5.0), 5.0/8.0);
 	  corner[2] = mix(mix(colorN[12], colorN[13], 2.0/3.0), mix(colorN[8], colorN[9], 3.0/5.0), 5.0/8.0);
 	  corner[3] = mix(mix(colorN[15], colorN[14], 2.0/3.0), mix(colorN[11], colorN[10], 3.0/5.0), 5.0/8.0);
-	  color = mix(mix(corner[0], corner[1], 0.5), mix(corner[2], corner[3], 0.5), 0.5);
+	  gl_FragColor = mix(mix(corner[0], corner[1], 0.5), mix(corner[2], corner[3], 0.5), 0.5);
 	}
 	else if (antialiasing == 4) {
-		color = mix(mix(colorN[0], colorN[1], 0.5), mix(colorN[2], colorN[3], 0.5), 0.5);
+		gl_FragColor = mix(mix(colorN[0], colorN[1], 0.5), mix(colorN[2], colorN[3], 0.5), 0.5);
 	}
 	else { //if antialiasing == 1
-		color = colorN[0];
+		gl_FragColor = colorN[0];
 	}
 }

--- a/src/main/resources/assets/flexfov/shaders/hammer.fs
+++ b/src/main/resources/assets/flexfov/shaders/hammer.fs
@@ -1,9 +1,9 @@
-#version 130
+#version 110
 
 #define M_PI 3.14159265
 
 /* This comes interpolated from the vertex shader */
-in vec2 texcoord;
+varying vec2 texcoord;
 
 /* The 6 textures to be rendered */
 uniform sampler2D texFront;
@@ -22,8 +22,6 @@ uniform vec4 backgroundColor;
 uniform vec2 cursorPos;
 
 uniform bool drawCursor;
-
-out vec4 color;
 
 vec3 rotate(vec3 ray, vec2 angle) {
 
@@ -141,12 +139,12 @@ void main(void) {
 	  corner[1] = mix(mix(colorN[3], colorN[2], 2.0/3.0), mix(colorN[7], colorN[6], 3.0/5.0), 5.0/8.0);
 	  corner[2] = mix(mix(colorN[12], colorN[13], 2.0/3.0), mix(colorN[8], colorN[9], 3.0/5.0), 5.0/8.0);
 	  corner[3] = mix(mix(colorN[15], colorN[14], 2.0/3.0), mix(colorN[11], colorN[10], 3.0/5.0), 5.0/8.0);
-	  color = mix(mix(corner[0], corner[1], 0.5), mix(corner[2], corner[3], 0.5), 0.5);
+	  gl_FragColor = mix(mix(corner[0], corner[1], 0.5), mix(corner[2], corner[3], 0.5), 0.5);
 	}
 	else if (antialiasing == 4) {
-		color = mix(mix(colorN[0], colorN[1], 0.5), mix(colorN[2], colorN[3], 0.5), 0.5);
+		gl_FragColor = mix(mix(colorN[0], colorN[1], 0.5), mix(colorN[2], colorN[3], 0.5), 0.5);
 	}
 	else { //if antialiasing == 1
-		color = colorN[0];
+		gl_FragColor = colorN[0];
 	}
 }

--- a/src/main/resources/assets/flexfov/shaders/panini.fs
+++ b/src/main/resources/assets/flexfov/shaders/panini.fs
@@ -1,7 +1,7 @@
-#version 130
+#version 110
 
 /* This comes interpolated from the vertex shader */
-in vec2 texcoord;
+varying vec2 texcoord;
 
 /* The 6 textures to be rendered */
 uniform sampler2D texFront;
@@ -21,8 +21,6 @@ uniform float fovy;
 uniform vec2 cursorPos;
 
 uniform bool drawCursor;
-
-out vec4 color;
 
 //copied from github.com/shaunlebron/flex-fov
 vec3 latlon_to_ray(float lat, float lon) {
@@ -146,12 +144,12 @@ void main(void) {
       corner[1] = mix(mix(colorN[3], colorN[2], 2.0/3.0), mix(colorN[7], colorN[6], 3.0/5.0), 5.0/8.0);
       corner[2] = mix(mix(colorN[12], colorN[13], 2.0/3.0), mix(colorN[8], colorN[9], 3.0/5.0), 5.0/8.0);
       corner[3] = mix(mix(colorN[15], colorN[14], 2.0/3.0), mix(colorN[11], colorN[10], 3.0/5.0), 5.0/8.0);
-      color = mix(mix(corner[0], corner[1], 0.5), mix(corner[2], corner[3], 0.5), 0.5);
+      gl_FragColor = mix(mix(corner[0], corner[1], 0.5), mix(corner[2], corner[3], 0.5), 0.5);
     }
     else if (antialiasing == 4) {
-        color = mix(mix(colorN[0], colorN[1], 0.5), mix(colorN[2], colorN[3], 0.5), 0.5);
+        gl_FragColor = mix(mix(colorN[0], colorN[1], 0.5), mix(colorN[2], colorN[3], 0.5), 0.5);
     }
     else { //if antialiasing == 1
-        color = colorN[0];
+        gl_FragColor = colorN[0];
     }
 }

--- a/src/main/resources/assets/flexfov/shaders/quad.vs
+++ b/src/main/resources/assets/flexfov/shaders/quad.vs
@@ -1,10 +1,10 @@
-#version 130
+#version 110
 
 /* The position of the vertex as two-dimensional vector */
-in vec2 vertex;
+attribute vec2 vertex;
 
 /* Write interpolated texture coordinate to fragment shader */
-out vec2 texcoord;
+varying vec2 texcoord;
 
 void main(void) {
   gl_Position = vec4(vertex, 0.0, 1.0);


### PR DESCRIPTION
trying this on mac crashes the game with the following error:

```
[06:51:36] [main/FATAL]: Unreported exception thrown!
java.lang.RuntimeException: Error creating shader: ERROR: 0:1: '' :  version '130' is not supported

    at net.id107.flexfov.ShaderManager.createShader(ShaderManager.java:46) ~[FlexFOV-1.0.5.jar:?]
…
```

converting them to glsl 1.10 fixed this error, but it still crashes (silently with no new error).